### PR TITLE
Junit windows fix

### DIFF
--- a/yamf-acceptancetests/src/main/java/nz/ac/wgtn/yamf/checks/junit/JUnitActions.java
+++ b/yamf-acceptancetests/src/main/java/nz/ac/wgtn/yamf/checks/junit/JUnitActions.java
@@ -49,8 +49,6 @@ public class JUnitActions {
 
         File junitReportFolder = new File(new File(JUNIT_REPORT_FOLDER),""+FOLDERNAME_FROM_TIMESTAMP_FORMAT.format(new Date())); // unique folder names
         junitReportFolder.mkdirs();
-        
-        
 
         ProcessResult result = null;
         if (classpath==null) {

--- a/yamf-acceptancetests/src/main/java/nz/ac/wgtn/yamf/checks/junit/JUnitActions.java
+++ b/yamf-acceptancetests/src/main/java/nz/ac/wgtn/yamf/checks/junit/JUnitActions.java
@@ -28,8 +28,8 @@ public class JUnitActions {
     public static final String JUPITER_REPORT_NAME = "TEST-junit-jupiter.xml";
     public static final String VINTAGE_REPORT_NAME = "TEST-junit-vintage.xml";
     
-    private static bool isWindows = false;
-    private static bool osChecked = false;
+    private static boolean isWindows = false;
+    private static boolean osChecked = false;
 
     public static final DateFormat FOLDERNAME_FROM_TIMESTAMP_FORMAT = new java.text.SimpleDateFormat("yyyy-MM-dd--HH-mm-ss--SSS");
 
@@ -116,7 +116,7 @@ public class JUnitActions {
         testResults.addToTestsWithErrors(testResultingInErrorCounts);
     }
     
-    private static ProcessResult adjustRunnerForWindows(String classpath, File junitRunner, File junitReportFolder, String testClass) {     
+    private static ProcessResult adjustRunnerForWindows(String classpath, File junitRunner, File junitReportFolder, String testClass) throws Exception {     
         //Prepend junit jar to classpath
         classpath = junitRunner.getAbsolutePath()+File.pathSeparator+classpath;
             
@@ -134,7 +134,7 @@ public class JUnitActions {
         cp2 += File.pathSeparator+mock;
         
         //Execute jar from classpath
-        result = OS.exe(new File("."), "java","-cp", cp2, "org.junit.platform.console.ConsoleLauncher", "-reports-dir",junitReportFolder.getAbsolutePath(),"-c",testClass);
+        return OS.exe(new File("."), "java","-cp", cp2, "org.junit.platform.console.ConsoleLauncher", "-reports-dir",junitReportFolder.getAbsolutePath(),"-c",testClass);
     }
     
     private static boolean checkOSisWindows() {


### PR DESCRIPTION
On Windows, the JUnit runner fails to correctly set the classpath when using the '-cp' argument, leading to 'ClassDefNotFound' exceptions.
To fix this issue, the JUnit jar has to be run as a typical Java class, i.e. through the Java classpath.
To accomplish this, the classpath is adjusted to look like the following (Using linux separator as an example):
  `<junit_runner>:<original_classpath>`

In addition the 'spring-mock' dependency is extracted from the original classpath, and moved to the end. Producing the following:
  `<junit_runner>:<classpath_without_spring-mock>:<spring-mock>`  

This is then run using:
  `java -cp <updated_classpath> <junit_runner_class> <junit_runner_args>`

Note: The JUnit runner main class is assumed to be: 'org.junit.platform.console.ConsoleLauncher'
